### PR TITLE
default protocol parameter to undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ class WebSocketClient {
    * @param url DOMString The URL to which to connect; this should be the URL to which the WebSocket server will respond.
    * @param protocols DOMString|DOMString[] Either a single protocol string or an array of protocol strings. These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified protocol). If you don't specify a protocol string, an empty string is assumed.
    */
-  constructor (url, protocols = null, options = {}) {
+  constructor (url, protocols, options = {}) {
     this.url = url
     this._protocols = protocols
 


### PR DESCRIPTION
Hi, thanks for putting this library together!

When initializing as follows: `new WebSocketClient('wss://....')`, I am getting the following error (in Chrome):

> Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received

This seems to be due to the `protocol` parameter being defaulted to `null`. Defaulting it to `undefined` instead, solves this issue.
